### PR TITLE
workflow: Replace JDK step with dedicated SBT step

### DIFF
--- a/.github/workflows/scala-windows.yml
+++ b/.github/workflows/scala-windows.yml
@@ -13,12 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'sbt'
+      - name: Setup Scala (sbt) (based on Adoptium)
+        uses: olafurpg/setup-scala@v10
 
       - name: Run tests
         run: sbt test


### PR DESCRIPTION
Windows workflow ended up taking around 4 minutes on average. I'm trying this now
